### PR TITLE
Fix deprecations

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -1,7 +1,7 @@
 @import "syntax-variables";
 @import "guides";
 
-atom-text-editor, :host {
+atom-text-editor,atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -52,274 +52,274 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region,
+atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region,
+atom-text-editor .search-results .syntax--marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }
 
-.comment {
+.syntax--comment {
   color: @light-gray;
 }
 
-.keyword {
+.syntax--keyword {
   color: @madoka;
 
-  &.control {
+  &.syntax--control {
     color: @madoka;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @syntax-text-color;
   }
 
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @homura;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @sayaka;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @sayaka;
 }
 
-.constant {
+.syntax--constant {
   color: @kyouko;
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @mami;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @mami;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @sayaka-off;
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @madoka-off;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @madoka;
 
   /* Custom for ruby */
-  .source.ruby.control {
+  .syntax--source.syntax--ruby.syntax--control {
     color: @homura;
   }
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: darken(@kyouko, 10%);
   }
 
-  &.parameter.function {
+  &.syntax--parameter.syntax--function {
     color: @syntax-text-color;
   }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   background-color: @kyouko-vibrant;
   color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
   color: @mami;
 
 
-  &.regexp {
+  &.syntax--regexp {
     color: @homura;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @kyouko;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @kyouko;
   }
 }
 
 
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @light-gray;
     }
 
-    &.string,
-    &.variable,
-    &.parameters,
-    &.array {
+    &.syntax--string,
+    &.syntax--variable,
+    &.syntax--parameters,
+    &.syntax--array {
       color: @syntax-text-color;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @sayaka;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @mami;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @madoka;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: darken(@kyouko, 10%);
   }
 
 }
 
-.support {
+.syntax--support {
 
-  &.class {
+  &.syntax--class {
     color: @sayaka;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @kyouko;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @sayaka;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @homura;
   }
-  &.name.type {
+  &.syntax--name.syntax--type {
     color: @madoka; // 23
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @madoka;
   }
-  &.name.class, &.name.type.class {
+  &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
     color: @mami;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @sayaka;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @kyouko;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @mami;
 
-    &.id {
+    &.syntax--id {
       color: @sayaka;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @mami;
   }
 
-  &.link {
+  &.syntax--link {
     color: @homura;
   }
 
-  &.require {
+  &.syntax--require {
     color: @sayaka;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @homura;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @gray;
     color: @syntax-text-color;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-text-color;
 }
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @homura;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @madoka;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @kyouko;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @homura-vibrant;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @sayaka-off;
   }
 // NOTE: Change maybe
-  &.inserted {
+  &.syntax--inserted {
     color: @madoka;
   }
 
-  &.list {
+  &.syntax--list {
     color: @kyouko;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @mami;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @madoka;
   }
 }
 
-.source.gfm .markup {
+.syntax--source.syntax--gfm .syntax--markup {
   -webkit-font-smoothing: auto;
-  &.heading {
+  &.syntax--heading {
     color: @madoka;
   }
 }
 
 atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
+atom-text-editor .scroll-view {
   padding-left: 1px;
 }
 
-.source.python {
-  .keyword.operator.logical.python {
+.syntax--source.syntax--python {
+  .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
     color: @madoka;
   }
 
-  .variable.parameter {
+  .syntax--variable.syntax--parameter {
     color: @nagisa;
   }
 }

--- a/styles/guides.less
+++ b/styles/guides.less
@@ -12,7 +12,7 @@
 }
 
 //highlights
-atom-text-editor::shadow .highlight {
+atom-text-editor.editor .highlight {
   &.find-result .region {
     background:transparent;
     border: 1px solid @madoka-off;


### PR DESCRIPTION
-Removed all `::shadow` and `::host` pseudo-selectors and prepended all
syntax selectors with `syntax--`.

-I love this syntax theme and really appreciate the time that it must have taken to put this all together. But because of the deprecations it would have been un-usable after a few updates from Atom. This is my first time digging even a little in to syntax themes, but I followed Atom's Deprecation Cop and hopefully this will fix the problems so I (and others) can continue to use this theme for the foreseeable future!